### PR TITLE
Parameterize author name and year for cleaner customization

### DIFF
--- a/coverpage.tex
+++ b/coverpage.tex
@@ -11,6 +11,8 @@
 
 \pagestyle{empty}
 
+\newcommand{\authorname}{Chan Ge Me} % Change only this parameter t oyour name
+
 \begin{document}
 	
 \begin{center}
@@ -23,7 +25,7 @@
 	
 	\vfill
 	
-	{\LARGE Firstname Lastname} % change this
+	{\LARGE \authorname}
 	
 	\vspace*{6em}
 	
@@ -37,7 +39,7 @@
 	
 	{\Large Szeged}
 	
-	{\Large YEAR} % change this
+	{\Large \the\year}
 \end{center}
 	
 \end{document}

--- a/coverpage.tex
+++ b/coverpage.tex
@@ -11,7 +11,7 @@
 
 \pagestyle{empty}
 
-\newcommand{\authorname}{Chan Ge Me} % Change only this parameter t oyour name
+\newcommand{\authorname}{Chan Ge Me} % Change only this parameter to your name
 
 \begin{document}
 	


### PR DESCRIPTION
**This change introduces a single configurable parameter for the author name and replaces hard-coded values with reusable macros.**

- Adds `\authorname` to centralize name configuration.

- Replaces the inline author string with `\authorname`.

- Uses `\the\year` instead of a fixed year to keep the template future-proof.

The goal is to keep the template clean and minimize the number of places that need modification, ensuring users only change one parameter instead of touching layout code.